### PR TITLE
Fix cors, postcreatecommand, scan_ruby CI

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -47,7 +47,11 @@
       }
     }
   },
-  "forwardPorts": [3000, 3306, 6379],
-  "postCreateCommand": "cp .env.sample .env && bundle install && bundle exec rails db:setup",
+  "forwardPorts": [
+    3000,
+    3306,
+    6379
+  ],
+  "postCreateCommand": "cp env.sample .env && bundle install && bundle exec rails db:setup",
   "remoteUser": "vscode"
 }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     bigdecimal (3.1.9)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
-    brakeman (7.0.0)
+    brakeman (7.0.2)
       racc
     builder (3.3.0)
     bundler-audit (0.9.2)

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,12 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins "example.com"
-#
-#     resource "*",
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins /.*\.github\.dev$/
+
+    resource "*",
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+  end
+end


### PR DESCRIPTION
fix 3 issues:
- default allow CORS from `github.dev` (for codespace development)
- fix `postCreateCommand` failing due to wrong file being called `.env.sample` instead of `env.sample`
- fix `scan_ruby` CI pipeline by updating brakeman to `7.0.2`